### PR TITLE
Lower zoom amount when scrolling!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ##Per kaiakairos (original author)
 This is a Godot 4.1.2 stable project. Not sure if everything will work in future version.
-Per kaiakairos (original author): "This code is very bad so be warned this is a SLOP project"
+This code is very bad so be warned this is a SLOP project
 
 ## Per filthy-cow (developer of this fork)
 The purpose of this fork is to add some Quality of Life features on top of the original!  I'll do my best to keep a list of notable changes here!

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
+##Per kaiakairos (original author)
 This is a Godot 4.1.2 stable project. Not sure if everything will work in future version.
-This code is very bad so be warned this is a SLOP project
+Per kaiakairos (original author): "This code is very bad so be warned this is a SLOP project"
+
+## Per filthy-cow (developer of this fork)
+The purpose of this fork is to add some Quality of Life features on top of the original!  I'll do my best to keep a list of notable changes here!
+
+###Quality of Life Changes so far:
+- Jul 2 2025: Smaller zoom increment (2.5% instead of 10% per scroll tick)

--- a/main_scenes/main.gd
+++ b/main_scenes/main.gd
@@ -211,14 +211,13 @@ func zoomScene():
 	#Handles Zooming
 	if Input.is_action_pressed("control"):
 		if Input.is_action_just_pressed("scrollUp"):
-			if scaleOverall < 400:
-				camera.zoom += Vector2(0.1,0.1)
-				scaleOverall += 10
-				changeZoom()
+			camera.zoom += Vector2(0.025,0.025)
+			scaleOverall += 2.5
+			changeZoom()
 		if Input.is_action_just_pressed("scrollDown"):
-			if scaleOverall > 10:
-				camera.zoom -= Vector2(0.1,0.1)
-				scaleOverall -= 10
+			if scaleOverall > 2.5:
+				camera.zoom -= Vector2(0.025,0.025)
+				scaleOverall -= 2.5
 				changeZoom()
 	
 	$ControlPanel/ZoomLabel.modulate.a = lerp($ControlPanel/ZoomLabel.modulate.a,0.0,0.02)


### PR DESCRIPTION
Basically, instead of zooming by 10% at a time in or out, break that down to 2.5% at a time.  this feels like a good middle ground between responsive zoom and getting a good zoom fit.